### PR TITLE
Fixed changes to support new solidus version

### DIFF
--- a/app/overrides/views/admin_subscribable_product_checkbox.rb
+++ b/app/overrides/views/admin_subscribable_product_checkbox.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
-Deface::Override.new(
-  virtual_path: "spree/admin/products/_form",
-  name: "solidus_subscriptions_product_subscribable_checkbox",
-  insert_after: "[data-hook='admin_product_form_promotionable']",
-  partial: "spree/admin/products/subscribable_checkbox"
-)
+module Views
+  module AdminSubscribableProductCheckbox
+    Deface::Override.new(
+      virtual_path: "spree/admin/products/_form",
+      name: "solidus_subscriptions_product_subscribable_checkbox",
+      insert_after: "[data-hook='admin_product_form_promotionable']",
+      partial: "spree/admin/products/subscribable_checkbox"
+    )
+  end
+end

--- a/app/overrides/views/admin_subscribable_variant_checkbox.rb
+++ b/app/overrides/views/admin_subscribable_variant_checkbox.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
-Deface::Override.new(
-  virtual_path: "spree/admin/variants/_form",
-  name: "solidus_subscriptions_variant_subscribable_checkbox",
-  insert_after: "[data-hook='track_inventory']",
-  partial: "spree/admin/variants/subscribable_checkbox"
-)
+module Views
+  module AdminSubscribableVariantCheckbox
+    Deface::Override.new(
+      virtual_path: "spree/admin/variants/_form",
+      name: "solidus_subscriptions_variant_subscribable_checkbox",
+      insert_after: "[data-hook='track_inventory']",
+      partial: "spree/admin/variants/subscribable_checkbox"
+    )
+  end
+end

--- a/app/overrides/views/admin_subscriptions_menu_link.rb
+++ b/app/overrides/views/admin_subscriptions_menu_link.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
-if !Spree::Backend::Config.respond_to?(:menu_items)
-  Deface::Override.new(
-    virtual_path: 'spree/admin/shared/_menu',
-    name: :add_subcriptions_admin_link,
-    insert_bottom: "[data-hook='admin_tabs']",
-    partial: 'spree/admin/shared/subscription_tab'
-  )
+module Views
+  module AdminSubscriptionsMenuLink
+    if !Spree::Backend::Config.respond_to?(:menu_items)
+      Deface::Override.new(
+        virtual_path: 'spree/admin/shared/_menu',
+        name: :add_subcriptions_admin_link,
+        insert_bottom: "[data-hook='admin_tabs']",
+        partial: 'spree/admin/shared/subscription_tab'
+      )
+    end
+  end
 end

--- a/app/overrides/views/admin_users_subscriptions_tab.rb
+++ b/app/overrides/views/admin_users_subscriptions_tab.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
-Deface::Override.new(
-  virtual_path: 'spree/admin/users/_tabs',
-  name: 'solidus_subscriptions_admin_users_subscriptions_tab',
-  insert_bottom: "[data-hook='admin_user_tab_options']",
-  partial: 'spree/admin/users/subscription_tab'
-)
+module Views
+  module AdminUsersSubscriptionsTab
+    Deface::Override.new(
+      virtual_path: 'spree/admin/users/_tabs',
+      name: 'solidus_subscriptions_admin_users_subscriptions_tab',
+      insert_bottom: "[data-hook='admin_user_tab_options']",
+      partial: 'spree/admin/users/subscription_tab'
+    )
+  end
+end

--- a/app/overrides/views/subscription_line_item_fields.rb
+++ b/app/overrides/views/subscription_line_item_fields.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
-Deface::Override.new(
-  virtual_path: "spree/products/_cart_form",
-  name: "subscription_line_item_fields",
-  insert_after: "[data-hook='inside_product_cart_form']",
-  partial: "spree/frontend/products/subscription_line_item_fields"
-)
+module Views
+  module SubscriptionLineItemFields
+    Deface::Override.new(
+      virtual_path: "spree/products/_cart_form",
+      name: "subscription_line_item_fields",
+      insert_after: "[data-hook='inside_product_cart_form']",
+      partial: "spree/frontend/products/subscription_line_item_fields"
+    )
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,13 +82,6 @@ en:
         name: Subscription Order
         description: Order fulfills a subscription
 
-    products:
-      cart_form:
-        quantity: I want
-        quantity_suffix: items
-        interval_length: every
-        subscription_fields: Subscription Settings
-
   activerecord:
     attributes:
       solidus_subscriptions/line_item/interval_units:

--- a/lib/generators/solidus_subscriptions/install/templates/app/views/cart_line_items/_subscription_fields.html.erb
+++ b/lib/generators/solidus_subscriptions/install/templates/app/views/cart_line_items/_subscription_fields.html.erb
@@ -1,30 +1,39 @@
-<%= content_tag :h3, t('.subscription_fields') %>
-<%= fields_for :'subscription_line_item', SolidusSubscriptions::LineItem.new do |ff| %>
-  <div>
-    <%= ff.label :quantity, t('.quantity') %>
-    <%= ff.number_field :quantity %>
-    <%= ff.label :quantity, t('.quantity_suffix') %>
-  </div>
+<% if @product.subscribable %>
+  <%= content_tag :h3, t('.subscription_fields') %>
+  <%= fields_for :'subscription_line_item', SolidusSubscriptions::LineItem.new do |ff| %>
+    <div>
+      <%= ff.label :quantity, t('.quantity') %>
+      <%= ff.number_field :quantity %>
+      <%= ff.label :quantity, t('.quantity_suffix') %>
+    </div>
 
-  <div>
-    <%= ff.label :interval_length, t('.interval_length') %>
-    <%= ff.number_field :interval_length %>
+    <div>
+      <%= ff.label :interval_length, t('.interval_length') %>
+      <%= ff.number_field :interval_length %>
 
-    <%= ff.collection_radio_buttons :interval_units, SolidusSubscriptions::LineItem.interval_units.to_a, :first, :first %>
-  </div>
+      <%= ff.collection_radio_buttons :interval_units, SolidusSubscriptions::LineItem.interval_units.to_a, :first, :first %>
+    </div>
 
-  <%= ff.hidden_field :subscribable_id %>
+    <%= ff.hidden_field :subscribable_id %>
+  <% end %>
 <% end %>
 
 <script>
   document.addEventListener("DOMContentLoaded", function(e) {
-    var cartForm = document.querySelector('.product-page__info form');
-    cartForm.addEventListener('submit', function(e) {
-      var quantityInput = e.target.querySelector('[name*="quantity"]');
-      var subscriptionQuantityInput = e.target.querySelector('[name*="subscribable_id"]');
+    var cartForm = document.querySelector('form[action="/cart_line_items"]');
 
-      subscriptionQuantityInput.value = quantityInput.value;
+    cartForm.addEventListener('submit', function(e) {
+      var variantInput = e.target.querySelector('[name*="variant_id"]:checked');
+      var subscribableInput = e.target.querySelector('[name*="subscription_line_item[subscribable_id]"]');
+
+      if (!variantInput) {
+        variantInput = cartForm.querySelector('[name="variant_id"]');
+      }
+
+      subscribableInput.value = variantInput.value;
+
       return true;
     });
   });
 </script>
+

--- a/lib/solidus_subscriptions/checkout.rb
+++ b/lib/solidus_subscriptions/checkout.rb
@@ -42,7 +42,6 @@ module SolidusSubscriptions
     end
 
     def finalize_order(order)
-      ::Spree::PromotionHandler::Cart.new(order).activate
       order.recalculate
 
       order.checkout_steps[0...-1].each do

--- a/lib/solidus_subscriptions/permission_sets/default_customer.rb
+++ b/lib/solidus_subscriptions/permission_sets/default_customer.rb
@@ -3,6 +3,16 @@
 module SolidusSubscriptions
   module PermissionSets
     class DefaultCustomer < ::Spree::PermissionSets::Base
+      class << self
+        def privilege
+          :customer
+        end
+
+        def category
+          :subscription
+        end
+      end
+
       def activate!
         can [:show, :display, :update, :skip, :cancel, :pause, :resume], Subscription, ['user_id = ?', user.id] do |subscription, guest_token|
           (subscription.guest_token.present? && subscription.guest_token == guest_token) ||

--- a/lib/solidus_subscriptions/permission_sets/subscription_management.rb
+++ b/lib/solidus_subscriptions/permission_sets/subscription_management.rb
@@ -3,6 +3,16 @@
 module SolidusSubscriptions
   module PermissionSets
     class SubscriptionManagement < ::Spree::PermissionSets::Base
+      class << self
+        def privilege
+          :manage
+        end
+
+        def category
+          :subscription
+        end
+      end
+
       def activate!
         can :manage, Subscription
         can :manage, LineItem

--- a/lib/solidus_subscriptions/subscription_line_item_builder.rb
+++ b/lib/solidus_subscriptions/subscription_line_item_builder.rb
@@ -9,8 +9,6 @@ module SolidusSubscriptions
         subscription_params.merge(spree_line_item: line_item)
       )
 
-      # Rerun the promotion handler to pickup subscription promotions
-      ::Spree::PromotionHandler::Cart.new(line_item.order).activate
       line_item.order.recalculate
     end
 


### PR DESCRIPTION
# Draft PR

## Dependency Updates, Form Adjustments, and New Privileges

This pull request resolves compatibility issues with Solidus version updates by adding necessary gem dependencies, modifying forms for proper field rendering, fixing jQuery issues with subscription creation, and updating permission sets. These changes align Solidus Subscriptions with the latest Solidus architecture. 

## Enhancements:
- **Dependency Addition**  
  - Added support for the new `solidus_legacy_promotions` gem, which is required as promotions have been separated from `solidus_core`.

- **Form Rendering Restriction**  
  - Updated the subscription fields form to render only when the associated product is subscribable.

- **jQuery Script Fix**  
  - Corrected the script used for creating subscription line items to ensure the correct `subscribable_id` is stored.

- **Permission Set Updates**  
  - Introduced new privilege and category methods for the permission sets to maintain compatibility with the latest Solidus versions.

Fixes: #304 #303 #302